### PR TITLE
Fix OWNER'S NOTES navigation

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,6 +39,7 @@ jobs:
             dist/index.html \
             dist/history/index.html \
             dist/history/smartwatch/index.html \
+            dist/owners-notes/index.html \
             dist/pierce-duofon/index.html \
             dist/cyma-time-o-vox/index.html \
             dist/cyma-time-o-vox/owners-note/index.html \
@@ -67,12 +68,16 @@ jobs:
           check_text '自分のために知らせる' dist/history/index.html
           check_text 'PARKING WATCH' dist/history/index.html
           check_text 'PIERCE DUOFON' dist/history/index.html
+          check_text 'owners-notes/' dist/index.html
+          check_text 'CYMA TIME-O-VOX 18K CHRONOMÈTRE' dist/owners-notes/index.html
+          check_text 'cyma-time-o-vox/owners-note/' dist/owners-notes/index.html
           check_text 'smartwatch-part-4.webp' dist/history/smartwatch/index.html
           check_text 'もっと静かな時代へ戻る' dist/history/smartwatch/index.html
           check_text '一つの香箱なのに、リューズは回らない。' dist/cyma-time-o-vox/index.html
           check_text '6〜10秒' dist/cyma-time-o-vox/index.html
           check_text '約9時間分のパワーリザーブ' dist/cyma-time-o-vox/index.html
           check_text 'owners-note-4.webp' dist/cyma-time-o-vox/index.html
+          check_text 'owners-notes' dist/sitemap.xml
           check_text 'cyma-time-o-vox' dist/sitemap.xml
       - name: Configure Pages
         uses: actions/configure-pages@v5
@@ -86,11 +91,15 @@ jobs:
       - name: Verify live site
         run: |
           root="${{ steps.deployment.outputs.page_url }}"
+          home="${root}"
           history="${root}history/"
+          owners="${root}owners-notes/"
           smart="${root}history/smartwatch/"
           cyma="${root}cyma-time-o-vox/"
           for attempt in {1..12}; do
+            home_html=$(curl -fsSL "$home" || true)
             history_html=$(curl -fsSL "$history" || true)
+            owners_html=$(curl -fsSL "$owners" || true)
             smart_html=$(curl -fsSL "$smart" || true)
             cyma_html=$(curl -fsSL "$cyma" || true)
             parts_ok=1
@@ -100,15 +109,18 @@ jobs:
               cyma_size=$(curl -fsSL "${root}images/cyma-time-o-vox/owners-note-${n}.webp" 2>/dev/null | wc -c || true)
               [ "${cyma_size:-0}" -gt 4000 ] || parts_ok=0
             done
-            if grep -Fq "自分のために知らせる" <<<"$history_html" \
+            if grep -Fq "owners-notes/" <<<"$home_html" \
+              && grep -Fq "自分のために知らせる" <<<"$history_html" \
               && grep -Fq "PARKING WATCH" <<<"$history_html" \
+              && grep -Fq "CYMA TIME-O-VOX 18K CHRONOMÈTRE" <<<"$owners_html" \
+              && grep -Fq "cyma-time-o-vox/owners-note/" <<<"$owners_html" \
               && grep -Fq "smartwatch-part-4.webp" <<<"$smart_html" \
               && grep -Fq "もっと静かな時代へ戻る" <<<"$smart_html" \
               && grep -Fq "一つの香箱なのに、リューズは回らない。" <<<"$cyma_html" \
               && grep -Fq "約9時間分のパワーリザーブ" <<<"$cyma_html" \
               && grep -Fq "owners-note-4.webp" <<<"$cyma_html" \
               && [ "$parts_ok" -eq 1 ]; then
-              echo "Verified live site, smartwatch artwork, and Cyma owner note: $root"
+              echo "Verified live site, owners notes directory, smartwatch artwork, and Cyma owner note: $root"
               exit 0
             fi
             sleep 5

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://orima1995-create.github.io/orima1995-creator.github.io/</loc></url>
   <url><loc>https://orima1995-create.github.io/orima1995-creator.github.io/history/</loc></url>
+  <url><loc>https://orima1995-create.github.io/orima1995-creator.github.io/owners-notes/</loc></url>
   <url><loc>https://orima1995-create.github.io/orima1995-creator.github.io/pierce-duofon/</loc></url>
   <url><loc>https://orima1995-create.github.io/orima1995-creator.github.io/cyma-time-o-vox/</loc></url>
   <url><loc>https://orima1995-create.github.io/orima1995-creator.github.io/history/smartwatch/</loc></url>

--- a/src/components/SectionMast.astro
+++ b/src/components/SectionMast.astro
@@ -9,7 +9,7 @@ const base = import.meta.env.BASE_URL;
       <nav class="section-menu-panel" aria-label="VINTAGE ALARM セクションメニュー">
         <a href={`${base}history/`}>歴史</a>
         <a href={`${base}history/#index-milestones`}>マイルストーン</a>
-        <a href={`${base}history/#index-owners`}>オーナーズノート</a>
+        <a href={`${base}owners-notes/`}>オーナーズノート</a>
         <a href={`${base}history/#index-interests`}>調査個体</a>
       </nav>
     </details>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ const schema = {
           <b>→</b>
         </a>
 
-        <a href={`${base}history/#index-owners`}>
+        <a href={`${base}owners-notes/`}>
           <span class="home-no">03</span>
           <div><strong>OWNER'S NOTES</strong><small>所有個体を、実機・操作・音から読む</small></div>
           <b>→</b>

--- a/src/pages/owners-notes/index.astro
+++ b/src/pages/owners-notes/index.astro
@@ -1,0 +1,87 @@
+---
+import { getCollection } from 'astro:content';
+import SeoHead from '../../components/SeoHead.astro';
+import SectionMast from '../../components/SectionMast.astro';
+import '../../styles/site.css';
+
+const base = import.meta.env.BASE_URL;
+const watches = (await getCollection('watches'))
+  .sort((a, b) => Number(a.data.ownerNumber) - Number(b.data.ownerNumber));
+
+const title = "OWNER'S NOTES｜所有アラーム腕時計の実機記録｜VINTAGE ALARM";
+const description = "VINTAGE ALARMのOWNER'S NOTE一覧。所有する機械式アラーム腕時計を、実機写真・操作・SPEC・機構資料とともに記録する。";
+const schema = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: "OWNER'S NOTES",
+  description,
+  inLanguage: 'ja',
+  url: 'https://orima1995-create.github.io/orima1995-creator.github.io/owners-notes/'
+};
+
+const watchName = (watch) => watch.data.slug === 'cyma-time-o-vox'
+  ? 'CYMA TIME-O-VOX 18K CHRONOMÈTRE'
+  : `${watch.data.brand} ${watch.data.model}`;
+
+const noteHref = (watch) => watch.data.ownersNote.zoomHref
+  ? `${base}${watch.data.ownersNote.zoomHref.replace(/^\//, '')}`
+  : `${base}${watch.data.slug}/#owners-note`;
+---
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#f3eee4" />
+    <SeoHead title={title} description={description} path="owners-notes/" schema={schema} />
+  </head>
+  <body>
+    <SectionMast rightLabel="OWNER'S NOTES" />
+    <main>
+      <section class="shell owners-directory-hero">
+        <div class="eyebrow">OWNER'S NOTES</div>
+        <h1>所有個体から、読む。</h1>
+        <p>カタログではなく、実際に手元へ来た時計の記録。OWNER'S NOTEから個体ページ、SPEC、機構資料へ辿る。</p>
+      </section>
+
+      <section class="shell owners-directory" aria-label="OWNER'S NOTE一覧">
+        {watches.map((watch) => (
+          <article class="owners-directory-card">
+            <div class="owners-directory-meta">
+              <span>OWNER'S NOTE / {watch.data.ownerNumber}</span>
+              <small>{watch.data.brand}</small>
+            </div>
+            <h2>{watchName(watch)}</h2>
+            <p class="owners-directory-catch">{watch.data.catch[0]}</p>
+            <div class="owners-directory-actions">
+              <a href={noteHref(watch)}>OWNER'S NOTEを見る →</a>
+              <a href={`${base}${watch.data.slug}/`}>個体ページへ →</a>
+            </div>
+          </article>
+        ))}
+      </section>
+    </main>
+
+    <style>
+      .owners-directory-hero{padding:88px 0 58px;border-bottom:1px solid var(--ink)}
+      .owners-directory-hero h1{max-width:12em;margin:18px 0 0;font-size:clamp(2.3rem,7vw,4.7rem);font-weight:500;line-height:1.05;text-wrap:balance}
+      .owners-directory-hero>p{max-width:42em;margin:30px 0 0;color:var(--soft);font-size:15px;line-height:1.9}
+      .owners-directory{padding-block:54px 90px}
+      .owners-directory-card{padding:30px 0;border-bottom:1px solid var(--ink)}
+      .owners-directory-card:first-child{border-top:1px solid var(--ink)}
+      .owners-directory-meta{display:flex;justify-content:space-between;gap:20px;color:var(--soft);font-family:Georgia,"Times New Roman",serif;font-size:10px;letter-spacing:.14em}
+      .owners-directory-card h2{margin:19px 0 0;font-family:Georgia,"Times New Roman",serif;font-size:clamp(1.8rem,4vw,3rem);font-weight:400;line-height:1.08;text-wrap:balance}
+      .owners-directory-catch{margin:18px 0 0;font-size:clamp(1.05rem,2.5vw,1.25rem);font-weight:600;line-height:1.5}
+      .owners-directory-actions{display:flex;flex-wrap:wrap;gap:14px 26px;margin-top:30px}
+      .owners-directory-actions a{display:inline-block;padding:7px 0;border-bottom:1px solid var(--ink);color:var(--ink);font-size:13px;text-decoration:none}
+      .owners-directory-actions a:hover{color:var(--red);border-bottom-color:var(--red)}
+      @media(max-width:480px){
+        .owners-directory-hero{padding:54px 0 42px}
+        .owners-directory{padding-block:38px 64px}
+        .owners-directory-card{padding:25px 0}
+        .owners-directory-actions{display:grid;gap:12px;margin-top:24px}
+        .owners-directory-actions a{width:max-content;max-width:100%}
+      }
+    </style>
+  </body>
+</html>


### PR DESCRIPTION
Fix broken OWNER'S NOTES entry points. Adds a dedicated /owners-notes/ directory generated from the watch content collection, routes the home and shared mast links there, exposes CYMA TIME-O-VOX 18K CHRONOMÈTRE with a direct OWNER'S NOTE link, adds the directory to the sitemap, and extends deployment verification so the navigation cannot silently break again.