### PR TITLE
Refactor HISTORY milestone cards to catalog data

### DIFF
--- a/REFACTOR_AUDIT.md
+++ b/REFACTOR_AUDIT.md
@@ -161,6 +161,29 @@
 - GitHub CI status: リポジトリ側のstatus checkは未設定（0件）
 - 結論: 本採用を妨げる問題なし
 
+### Step 1F — MILESTONESカードをカタログから生成
+
+- 変更: `src/pages/history/index.astro`
+- 対象: 1910s / 1940s / 1950s の MILESTONES カードのみ
+- ETERNA ALARM / CRICKET / MEMOVOX / AS 1475 を `src/data/history-catalog.ts` の `historyCatalogByGroup.milestones` から年代別に静的生成するよう変更
+- OWNER'S NOTES / RESEARCH / 1960s–70s の BRANCH カードは未変更
+- HTMLクラス、カード配置、既存アンカー、本文、SEO、CSS、クライアントJavaScriptは変更しない
+
+#### Step 1F 監査結果
+
+- mainとの差分: `src/pages/history/index.astro` のMILESTONES生成部分と本監査ログのみ
+- コード差分を全件確認し、MILESTONES以外の本文・カード・リンクに意図しない変更なし
+- データ照合: 4カードすべてで `meta` / `name` / `hook` / `cardSummary` / `cardStatus` が従来の直書き文言と一致
+- 順序: 1910s ETERNA → 1940s CRICKET → 1950s MEMOVOX / AS 1475 を維持
+- URL / anchor: 変更なし
+- SEO: 変更なし
+- CSS変更: なし
+- JavaScript変更: なし
+- ライブラリ追加: なし
+- PR #9 の Astro foundation check: build / Verify site output ともに成功
+- main / 本番: この監査記録時点では未変更
+- 次: OWNER'S NOTESカードのカタログ生成へ進む前に、本Stepだけを本採用して公開後監査する
+
 ## 方針
 
 速度改善のためにフレームワークやライブラリを増やさない。

--- a/src/pages/history/index.astro
+++ b/src/pages/history/index.astro
@@ -1,9 +1,11 @@
 ---
 import SeoHead from '../../components/SeoHead.astro';
 import SectionMast from '../../components/SectionMast.astro';
+import { historyCatalogByGroup } from '../../data/history-catalog';
 import '../../styles/site.css';
 import '../../styles/history-magazine.css';
 const base = import.meta.env.BASE_URL;
+const milestoneCards = (era: '1910s' | '1940s' | '1950s') => historyCatalogByGroup.milestones.filter((entry) => entry.era === era && entry.featured);
 const title = 'アラーム腕時計の歴史｜Eterna・Cricket・Memovox・Duofon・Time-O-Vox｜VINTAGE ALARM';
 const description = '鐘で共有された時間から、懐中時計、アラーム腕時計へ。Eterna、Vulcain Cricket、Memovox、AS 1475、Pierce Duofon、Cyma Time-O-Vox、Parking Watch、電子化まで、「時間を知らせる」腕時計の歴史を辿る。';
 const schema = {
@@ -139,13 +141,15 @@ const schema = {
                 <div><span>MILESTONES</span><p>歴史上の節目</p></div>
               </div>
               <div class="history-card-track" data-track>
-                <article class="history-card history-card-milestone">
-                  <small>1914 / ETERNA</small>
-                  <h3>ETERNA ALARM</h3>
-                  <p class="history-card-hook">アラームを、腕時計のサイズへ。</p>
-                  <p>一つの香箱から時刻とアラームを動かす、最初期の量産アラーム腕時計。</p>
-                  <span class="history-card-status">MILESTONE</span>
-                </article>
+                {milestoneCards('1910s').map((entry) => (
+                  <article class="history-card history-card-milestone">
+                    <small>{entry.meta}</small>
+                    <h3>{entry.name}</h3>
+                    <p class="history-card-hook">{entry.hook}</p>
+                    <p>{entry.cardSummary}</p>
+                    <span class="history-card-status">{entry.cardStatus}</span>
+                  </article>
+                ))}
               </div>
             </div>
           </div>
@@ -181,13 +185,15 @@ const schema = {
                 <div><span>MILESTONES</span><p>歴史上の節目</p></div>
               </div>
               <div class="history-card-track" data-track>
-                <article class="history-card history-card-milestone">
-                  <small>1947 / VULCAIN</small>
-                  <h3>CRICKET</h3>
-                  <p class="history-card-hook">腕につけたまま、聞こえる音を。</p>
-                  <p>二重底の音響構造で、装着時のアラーム音を実用的なレベルへ押し上げた。</p>
-                  <span class="history-card-status">MILESTONE</span>
-                </article>
+                {milestoneCards('1940s').map((entry) => (
+                  <article class="history-card history-card-milestone">
+                    <small>{entry.meta}</small>
+                    <h3>{entry.name}</h3>
+                    <p class="history-card-hook">{entry.hook}</p>
+                    <p>{entry.cardSummary}</p>
+                    <span class="history-card-status">{entry.cardStatus}</span>
+                  </article>
+                ))}
               </div>
             </div>
 
@@ -236,20 +242,15 @@ const schema = {
                 </div>
               </div>
               <div class="history-card-track" data-track>
-                <article class="history-card history-card-milestone">
-                  <small>1951 / JAEGER-LECOULTRE</small>
-                  <h3>MEMOVOX</h3>
-                  <p class="history-card-hook">アラーム専用の動力を持つ。</p>
-                  <p>時刻用とアラーム用に独立した2つの香箱を持つ、代表的な二香箱構成。</p>
-                  <span class="history-card-status">MILESTONE</span>
-                </article>
-                <article class="history-card history-card-milestone">
-                  <small>1954 / A. SCHILD</small>
-                  <h3>AS 1475</h3>
-                  <p class="history-card-hook">アラームを、もっと多くの腕へ。</p>
-                  <p>多数のブランドへ広がり、アラーム腕時計の裾野を大きく広げた量産ムーブメント。</p>
-                  <span class="history-card-status">MILESTONE</span>
-                </article>
+                {milestoneCards('1950s').map((entry) => (
+                  <article class="history-card history-card-milestone">
+                    <small>{entry.meta}</small>
+                    <h3>{entry.name}</h3>
+                    <p class="history-card-hook">{entry.hook}</p>
+                    <p>{entry.cardSummary}</p>
+                    <span class="history-card-status">{entry.cardStatus}</span>
+                  </article>
+                ))}
               </div>
             </div>
 


### PR DESCRIPTION
Safe refactor Step 1F.

Scope is intentionally narrow:
- Render only the HISTORY MILESTONES cards for 1910s / 1940s / 1950s from `src/data/history-catalog.ts`.
- Preserve card order, wording, classes, anchors, SEO, CSS and client JavaScript.
- OWNER'S NOTES, RESEARCH and 1960s BRANCH cards remain untouched.

Audit result:
- Astro build passed.
- Verify site output passed.
- Diff is limited to HISTORY milestone rendering plus REFACTOR_AUDIT.md.

Closed only because the connector failed to convert this draft PR to ready-for-review; superseded by a non-draft PR with the same head branch.