### PR TITLE
Refactor HISTORY research cards to catalog data

### DIFF
--- a/src/data/history-catalog.ts
+++ b/src/data/history-catalog.ts
@@ -144,7 +144,7 @@ export const historyCatalog: HistoryCatalogEntry[] = [
     name: 'PARKING WATCH',
     hook: '駐車時間まで、腕が知らせる。',
     cardSummary: 'アラームを「起こす」以外の生活用途へ使う、気になる系譜。',
-    cardStatus: 'RESEARCHING →',
+    cardStatus: 'RESEARCHING',
     href: '#1950s',
     hrefKind: 'hash',
     featured: true

--- a/src/pages/history/index.astro
+++ b/src/pages/history/index.astro
@@ -7,6 +7,7 @@ import '../../styles/history-magazine.css';
 const base = import.meta.env.BASE_URL;
 const milestoneCards = (era: '1910s' | '1940s' | '1950s') => historyCatalogByGroup.milestones.filter((entry) => entry.era === era && entry.featured);
 const ownerCards = (era: '1940s' | '1950s') => historyCatalogByGroup.owners.filter((entry) => entry.era === era && entry.featured);
+const researchCards = (era: '1950s') => historyCatalogByGroup.research.filter((entry) => entry.era === era && entry.featured);
 const title = 'アラーム腕時計の歴史｜Eterna・Cricket・Memovox・Duofon・Time-O-Vox｜VINTAGE ALARM';
 const description = '鐘で共有された時間から、懐中時計、アラーム腕時計へ。Eterna、Vulcain Cricket、Memovox、AS 1475、Pierce Duofon、Cyma Time-O-Vox、Parking Watch、電子化まで、「時間を知らせる」腕時計の歴史を辿る。';
 const schema = {
@@ -305,13 +306,25 @@ const schema = {
                 <div><span>気になっているもの</span><p>調査・探索を続けたい時計</p></div>
               </div>
               <div class="history-card-track" data-track>
-                <article class="history-card history-card-interest">
-                  <small>1957 / JLC PARKING PATENT</small>
-                  <h3>PARKING WATCH</h3>
-                  <p class="history-card-hook">駐車時間まで、腕が知らせる。</p>
-                  <p>アラームを「起こす」以外の生活用途へ使う、気になる系譜。</p>
-                  <span class="history-card-status">RESEARCHING</span>
-                </article>
+                {researchCards('1950s').map((entry) => (
+                  entry.hrefKind === 'site' ? (
+                    <a class="history-card history-card-interest history-card-link" href={`${base}${entry.href}`}>
+                      <small>{entry.meta}</small>
+                      <h3>{entry.name}</h3>
+                      <p class="history-card-hook">{entry.hook}</p>
+                      <p>{entry.cardSummary}</p>
+                      <span class="history-card-status">{entry.cardStatus}</span>
+                    </a>
+                  ) : (
+                    <article class="history-card history-card-interest">
+                      <small>{entry.meta}</small>
+                      <h3>{entry.name}</h3>
+                      <p class="history-card-hook">{entry.hook}</p>
+                      <p>{entry.cardSummary}</p>
+                      <span class="history-card-status">{entry.cardStatus}</span>
+                    </article>
+                  )
+                ))}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Safe refactor Step 1H.

Scope:
- First align the Parking Watch catalog status with the current live card (`RESEARCHING`, no arrow) so generated output cannot change visibly.
- Render only the 1950s RESEARCH card(s) from `src/data/history-catalog.ts`.
- Keep current non-link behavior for hash entries; future published `site` entries can become links without duplicating card copy.
- Preserve wording, order, classes, `#research`, SEO, CSS and client JavaScript.
- MILESTONES, OWNER'S NOTES and 1960s BRANCH cards are not changed.

Audit before merge:
- Diff must stay limited to the one catalog status alignment and RESEARCH card rendering.
- Astro build and output verification must pass.
- PARKING WATCH and `RESEARCHING` must remain in HISTORY; `#research` must remain live.
- No main merge until isolated checks pass.