### PR TITLE
Extract HISTORY 1940s chapter copy from layout

### DIFF
--- a/src/data/history-content.ts
+++ b/src/data/history-content.ts
@@ -30,5 +30,17 @@ export const historyContent = {
     teaser: 'Eterna Patent 42,203。懐中時計の延長ではなく、腕時計サイズのアラームへ。',
     overline: 'PATENT 42,203 / 1908 → SERIES PRODUCTION / 1914',
     intro: 'Eternaは1908年、13リーニュのアラーム腕時計機構について特許42,203を取得した。1914年からシリーズ生産が始まり、専門文献では最初のシリーズ生産アラーム腕時計として位置づけられている。'
+  },
+  era1940s: {
+    chapterNo: '02',
+    label: '1940s',
+    title: '腕につけたまま、聞こえる音を。',
+    teaser: 'ケースを守るほど音は逃げない。Cricketが音響の問題を大きく前へ進める。',
+    overline: 'THE CONTRADICTION',
+    problemTitleLead: '腕に載せたら、',
+    problemTitleStrong: '音と密閉が喧嘩した。',
+    problemLines: ['小さくする。', '動力を確保する。', '水と埃を防ぐ。'],
+    problemStrong: 'でも、音は外へ出したい。',
+    problemCopy: '腕時計は外へ持ち出される。ケースを閉じて機構を守りたい。一方で、閉じるほどアラーム音は外へ届きにくくなる。小型化だけでは終わらなかった。'
   }
 } as const;

--- a/src/pages/history/index.astro
+++ b/src/pages/history/index.astro
@@ -11,6 +11,7 @@ const ownerCards = (era: '1940s' | '1950s') => historyCatalogByGroup.owners.filt
 const researchCards = (era: '1950s') => historyCatalogByGroup.research.filter((entry) => entry.era === era && entry.featured);
 const before = historyContent.before;
 const era1910s = historyContent.era1910s;
+const era1940s = historyContent.era1940s;
 const title = 'アラーム腕時計の歴史｜Eterna・Cricket・Memovox・Duofon・Time-O-Vox｜VINTAGE ALARM';
 const description = '鐘で共有された時間から、懐中時計、アラーム腕時計へ。Eterna、Vulcain Cricket、Memovox、AS 1475、Pierce Duofon、Cyma Time-O-Vox、Parking Watch、電子化まで、「時間を知らせる」腕時計の歴史を辿る。';
 const schema = {
@@ -160,26 +161,24 @@ const schema = {
 
         <details class="history-chapter" id="1940s">
           <summary class="shell history-chapter-summary">
-            <span class="history-chapter-no">02</span>
+            <span class="history-chapter-no">{era1940s.chapterNo}</span>
             <span class="history-chapter-heading">
-              <small>1940s</small>
-              <strong>腕につけたまま、聞こえる音を。</strong>
+              <small>{era1940s.label}</small>
+              <strong>{era1940s.title}</strong>
             </span>
-            <span class="history-chapter-teaser">ケースを守るほど音は逃げない。Cricketが音響の問題を大きく前へ進める。</span>
+            <span class="history-chapter-teaser">{era1940s.teaser}</span>
             <span class="history-chapter-toggle" aria-hidden="true">＋</span>
           </summary>
           <div class="history-chapter-body">
             <div class="history-problem-stage history-problem-stage-nested">
               <div class="shell history-problem-stage-inner">
-                <p class="history-overline">THE CONTRADICTION</p>
-                <h2 class="history-problem-title">腕に載せたら、<br />音と密閉が喧嘩した。</h2>
+                <p class="history-overline">{era1940s.overline}</p>
+                <h2 class="history-problem-title">{era1940s.problemTitleLead}<br />{era1940s.problemTitleStrong}</h2>
                 <div class="history-problem-lines" aria-label="腕時計化で生じた問題">
-                  <span>小さくする。</span>
-                  <span>動力を確保する。</span>
-                  <span>水と埃を防ぐ。</span>
-                  <strong>でも、音は外へ出したい。</strong>
+                  {era1940s.problemLines.map((line) => <span>{line}</span>)}
+                  <strong>{era1940s.problemStrong}</strong>
                 </div>
-                <p class="history-problem-copy">腕時計は外へ持ち出される。ケースを閉じて機構を守りたい。一方で、閉じるほどアラーム音は外へ届きにくくなる。小型化だけでは終わらなかった。</p>
+                <p class="history-problem-copy">{era1940s.problemCopy}</p>
               </div>
             </div>
 


### PR DESCRIPTION
Safe refactor Step 2C.

Scope:
- Extend `src/data/history-content.ts` with the existing 1940s chapter copy only.
- Render the 1940s chapter heading, teaser and THE CONTRADICTION problem-stage copy from that data.
- Preserve the intentional problem-title line break, `#1940s` anchor, Cricket MILESTONE shelf, Basis OWNER'S NOTES shelf, classes, SEO, CSS and client JavaScript.
- BEFORE / 1910s remain on their proven content-data paths; 1950s onward remain untouched.

Audit before merge:
- Diff limited to `history-content.ts` and 1940s bindings in `history/index.astro`.
- Astro build and Verify site output must pass.
- All problem-stage strings and emphasis boundaries must remain unchanged.
- MILESTONES / OWNER'S NOTES rendering must remain unchanged.
- No dependency, CSS, JS or SEO changes.
- Merge only after isolated checks succeed; then require production live verification.