### PR TITLE
Extract HISTORY current section copy from layout

### DIFF
--- a/src/data/history-content.ts
+++ b/src/data/history-content.ts
@@ -70,5 +70,12 @@ export const historyContent = {
       '機械式では、香箱、ハンマー、音響体、停止機構を小さなケースへ組み込む必要があった。電子化すると、アラームは回路と電子音で実現できる。',
       'アラームは消えなかった。むしろ、時計に付いていて当然の機能へ近づいていった。'
     ]
+  },
+  current: {
+    storyNo: '06 / CURRENT',
+    title: '現状の到達点。',
+    name: 'SMARTWATCH',
+    linkLabel: '見る →',
+    href: 'history/smartwatch/'
   }
 } as const;

--- a/src/pages/history/index.astro
+++ b/src/pages/history/index.astro
@@ -15,6 +15,7 @@ const era1940s = historyContent.era1940s;
 const era1950s = historyContent.era1950s;
 const era1960s = historyContent.era1960s;
 const electronic = historyContent.electronic;
+const current = historyContent.current;
 const title = 'アラーム腕時計の歴史｜Eterna・Cricket・Memovox・Duofon・Time-O-Vox｜VINTAGE ALARM';
 const description = '鐘で共有された時間から、懐中時計、アラーム腕時計へ。Eterna、Vulcain Cricket、Memovox、AS 1475、Pierce Duofon、Cyma Time-O-Vox、Parking Watch、電子化まで、「時間を知らせる」腕時計の歴史を辿る。';
 const schema = {
@@ -400,10 +401,10 @@ const schema = {
 
       <section class="history-current" id="current">
         <div class="shell history-current-inner">
-          <p class="history-story-no">06 / CURRENT</p>
-          <h2>現状の到達点。</h2>
-          <p class="history-current-name">SMARTWATCH</p>
-          <a class="history-next" href={`${base}history/smartwatch/`}>見る →</a>
+          <p class="history-story-no">{current.storyNo}</p>
+          <h2>{current.title}</h2>
+          <p class="history-current-name">{current.name}</p>
+          <a class="history-next" href={`${base}${current.href}`}>{current.linkLabel}</a>
         </div>
       </section>
 


### PR DESCRIPTION
Safe refactor Step 2G.

Scope:
- Extend `src/data/history-content.ts` with the existing CURRENT section copy and existing smartwatch href only.
- Render the CURRENT story number, title, name and link label/href from that data.
- Preserve the `#current` anchor, classes, visible wording, smartwatch destination, SEO, CSS and client JavaScript.
- All previous HISTORY chapter data paths remain untouched; HERO, index and sources remain hardcoded for now.

Audit before merge:
- Diff limited to `history-content.ts` and CURRENT bindings in `history/index.astro`.
- Astro build and Verify site output must pass.
- No wording, dependency, CSS, JS or SEO changes.
- Merge only after isolated checks succeed; then require production live verification.