### PR TITLE
Extract HISTORY hero copy from layout

### DIFF
--- a/src/data/history-content.ts
+++ b/src/data/history-content.ts
@@ -1,4 +1,16 @@
 export const historyContent = {
+  hero: {
+    eyebrow: 'HISTORY OF ALARM WRISTWATCHES',
+    title: 'アラームを、腕へ。',
+    kicker: ['時間を見る。', '時間になったら、知らされる。'],
+    lead: [
+      'いまでは当たり前のこの二つは、最初から一緒だったわけではない。',
+      '人はまず、時間を共有した。次に、自分で時間を持つようになった。'
+    ],
+    emphasisLead: 'そして、',
+    emphasis: '自分の時間を、自分のために知らせる。',
+    tail: 'その仕組みまで腕へ載せようとした。'
+  },
   before: {
     chapterNo: '00',
     label: 'BEFORE THE WRIST',

--- a/src/pages/history/index.astro
+++ b/src/pages/history/index.astro
@@ -9,6 +9,7 @@ const base = import.meta.env.BASE_URL;
 const milestoneCards = (era: '1910s' | '1940s' | '1950s') => historyCatalogByGroup.milestones.filter((entry) => entry.era === era && entry.featured);
 const ownerCards = (era: '1940s' | '1950s') => historyCatalogByGroup.owners.filter((entry) => entry.era === era && entry.featured);
 const researchCards = (era: '1950s') => historyCatalogByGroup.research.filter((entry) => entry.era === era && entry.featured);
+const hero = historyContent.hero;
 const before = historyContent.before;
 const era1910s = historyContent.era1910s;
 const era1940s = historyContent.era1940s;
@@ -74,14 +75,13 @@ const schema = {
 
     <main>
       <section class="shell history-hero history-hero-magazine">
-        <div class="eyebrow">HISTORY OF ALARM WRISTWATCHES</div>
-        <h1>アラームを、腕へ。</h1>
-        <p class="history-kicker">時間を見る。<br class="history-title-break" />時間になったら、知らされる。</p>
+        <div class="eyebrow">{hero.eyebrow}</div>
+        <h1>{hero.title}</h1>
+        <p class="history-kicker">{hero.kicker[0]}<br class="history-title-break" />{hero.kicker[1]}</p>
         <div class="history-lead">
-          <p>いまでは当たり前のこの二つは、最初から一緒だったわけではない。</p>
-          <p>人はまず、時間を共有した。次に、自分で時間を持つようになった。</p>
-          <p>そして、<strong>自分の時間を、自分のために知らせる。</strong></p>
-          <p>その仕組みまで腕へ載せようとした。</p>
+          {hero.lead.map((paragraph) => <p>{paragraph}</p>)}
+          <p>{hero.emphasisLead}<strong>{hero.emphasis}</strong></p>
+          <p>{hero.tail}</p>
         </div>
       </section>
 


### PR DESCRIPTION
Safe refactor Step 2H.

Scope:
- Extend `src/data/history-content.ts` with the existing HISTORY hero copy only.
- Render eyebrow, H1, two-line kicker and the existing four lead paragraphs from that data.
- Preserve the intentional kicker line break, strong emphasis placement, classes, visible wording, SEO, CSS and client JavaScript.
- HISTORY index, chapters, CURRENT and sources remain otherwise untouched.

Audit before merge:
- Diff limited to `history-content.ts` and HERO bindings in `history/index.astro`.
- Astro build and Verify site output must pass.
- No wording, dependency, CSS, JS or SEO changes.
- Merge only after isolated checks succeed; then require production live verification.