### PR TITLE
Extract HISTORY branches cards from layout

### DIFF
--- a/src/data/history-content.ts
+++ b/src/data/history-content.ts
@@ -71,7 +71,23 @@ export const historyContent = {
     label: '1960s–70s',
     title: '用途と複合機能へ。',
     teaser: '自動巻、日付、潜水、第二時間帯。アラームは他の機能と結びついていく。',
-    intro: '1950年代までに多様な基本構成が現れ、その後はアラームを自動巻、日付、スポーツ用途、旅行用途などと組み合わせる展開が広がった。'
+    intro: '1950年代までに多様な基本構成が現れ、その後はアラームを自動巻、日付、スポーツ用途、旅行用途などと組み合わせる展開が広がった。',
+    branches: [
+      {
+        meta: 'AUTOMATIC / DATE',
+        name: 'DAILY USE',
+        hook: '巻く手間を減らし、日常機能を足す。',
+        summary: '自動巻や日付との組み合わせで、アラームは日常時計の一機能へ近づいていく。',
+        status: 'BRANCH'
+      },
+      {
+        meta: 'DIVER / TRAVEL',
+        name: 'BEYOND THE DESK',
+        hook: '潜る。旅する。別の時間を扱う。',
+        summary: '高防水、潜水、第二時間帯など、アラームは使われる場所そのものを広げた。',
+        status: 'BRANCH'
+      }
+    ]
   },
   electronic: {
     chapterNo: '05',

--- a/src/pages/history/index.astro
+++ b/src/pages/history/index.astro
@@ -366,20 +366,15 @@ const schema = {
                 </div>
               </div>
               <div class="history-card-track" data-track>
-                <article class="history-card history-card-milestone">
-                  <small>AUTOMATIC / DATE</small>
-                  <h3>DAILY USE</h3>
-                  <p class="history-card-hook">巻く手間を減らし、日常機能を足す。</p>
-                  <p>自動巻や日付との組み合わせで、アラームは日常時計の一機能へ近づいていく。</p>
-                  <span class="history-card-status">BRANCH</span>
-                </article>
-                <article class="history-card history-card-milestone">
-                  <small>DIVER / TRAVEL</small>
-                  <h3>BEYOND THE DESK</h3>
-                  <p class="history-card-hook">潜る。旅する。別の時間を扱う。</p>
-                  <p>高防水、潜水、第二時間帯など、アラームは使われる場所そのものを広げた。</p>
-                  <span class="history-card-status">BRANCH</span>
-                </article>
+                {era1960s.branches.map((branch) => (
+                  <article class="history-card history-card-milestone">
+                    <small>{branch.meta}</small>
+                    <h3>{branch.name}</h3>
+                    <p class="history-card-hook">{branch.hook}</p>
+                    <p>{branch.summary}</p>
+                    <span class="history-card-status">{branch.status}</span>
+                  </article>
+                ))}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Safe refactor Step 2K.

Scope:
- Move only the two existing 1960s–70s BRANCHES card texts into `history-content.ts` under `era1960s.branches`.
- Render those two cards in the same order with the same classes and wording.
- Keep BRANCHES shelf heading, controls, `#1960s` anchor, chapter intro, SEO, CSS and client JavaScript unchanged.
- Do not mix these branch cards into MILESTONES / OWNER'S NOTES / RESEARCH catalog groups.

Audit before merge:
- Diff limited to `history-content.ts` branch-card data and the BRANCHES card rendering in `history/index.astro`.
- Astro build and Verify site output must pass.
- Exact card text/order/status must remain unchanged.
- Merge only after isolated checks succeed; then require production live verification.