### PR TITLE
Add HISTORY editor to Pages CMS

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -99,3 +99,169 @@ content:
         label: 参考資料・出典
         type: string
         list: true
+
+  - name: history
+    label: HISTORY 編集
+    type: file
+    path: src/data/history-content.json
+    format: json
+    fields:
+      - name: hero
+        label: 冒頭 / HERO
+        type: object
+        required: true
+        fields:
+          - { name: eyebrow, label: 英文見出し, type: string }
+          - { name: title, label: タイトル, type: string }
+          - name: kicker
+            label: 導入2行
+            type: string
+            list:
+              min: 2
+              max: 2
+          - name: lead
+            label: 導入本文
+            type: text
+            list: true
+          - { name: emphasisLead, label: 強調前, type: string }
+          - { name: emphasis, label: 強調文, type: text }
+          - { name: tail, label: 締め, type: text }
+
+      - name: before
+        label: 00 / BEFORE THE WRIST
+        type: object
+        required: true
+        fields:
+          - { name: chapterNo, label: Chapter No., type: string, readonly: true }
+          - { name: label, label: 章ラベル, type: string, readonly: true }
+          - { name: title, label: 章タイトル, type: string }
+          - { name: teaser, label: 目次・要約, type: text }
+          - { name: overline, label: Overline, type: string }
+          - name: intro
+            label: 導入本文
+            type: text
+            list: true
+          - { name: infrastructureEmphasis, label: 強調文, type: text }
+          - { name: turnLead, label: 転換文 前半, type: string }
+          - { name: turnStrong, label: 転換文 強調, type: string }
+          - { name: portableTitle, label: 小見出し / ポケットへ, type: string }
+          - name: portable
+            label: ポケットへ 本文
+            type: text
+            list: true
+          - { name: portableEmphasis, label: ポケットへ 強調, type: text }
+          - { name: alarmTitle, label: 小見出し / アラームへ, type: string }
+          - name: alarm
+            label: アラームへ 本文
+            type: text
+            list: true
+
+      - name: era1910s
+        label: 01 / 1910s
+        type: object
+        required: true
+        fields:
+          - { name: chapterNo, label: Chapter No., type: string, readonly: true }
+          - { name: label, label: 章ラベル, type: string, readonly: true }
+          - { name: title, label: 章タイトル, type: string }
+          - { name: teaser, label: 目次・要約, type: text }
+          - { name: overline, label: Overline, type: string }
+          - { name: intro, label: 本文, type: text }
+
+      - name: era1940s
+        label: 02 / 1940s
+        type: object
+        required: true
+        fields:
+          - { name: chapterNo, label: Chapter No., type: string, readonly: true }
+          - { name: label, label: 章ラベル, type: string, readonly: true }
+          - { name: title, label: 章タイトル, type: string }
+          - { name: teaser, label: 目次・要約, type: text }
+          - { name: overline, label: Overline, type: string }
+          - { name: problemTitleLead, label: 問題提起 前半, type: string }
+          - { name: problemTitleStrong, label: 問題提起 強調, type: string }
+          - name: problemLines
+            label: 問題点
+            type: string
+            list: true
+          - { name: problemStrong, label: 問題点 強調, type: string }
+          - { name: problemCopy, label: 本文, type: text }
+
+      - name: era1950s
+        label: 03 / 1950s
+        type: object
+        required: true
+        fields:
+          - { name: chapterNo, label: Chapter No., type: string, readonly: true }
+          - { name: label, label: 章ラベル, type: string, readonly: true }
+          - { name: title, label: 章タイトル, type: string }
+          - { name: teaser, label: 目次・要約, type: text }
+          - { name: thesis, label: Thesis, type: string }
+          - { name: lead, label: 導入本文, type: text }
+          - { name: editorialLead, label: 編集方針 前半, type: text }
+          - { name: editorialStrong, label: 編集方針 強調, type: text }
+          - { name: editorialTail, label: 編集方針 後半, type: string }
+
+      - name: era1960s
+        label: 04 / 1960s–70s
+        type: object
+        required: true
+        fields:
+          - { name: chapterNo, label: Chapter No., type: string, readonly: true }
+          - { name: label, label: 章ラベル, type: string, readonly: true }
+          - { name: title, label: 章タイトル, type: string }
+          - { name: teaser, label: 目次・要約, type: text }
+          - { name: intro, label: 導入本文, type: text }
+          - name: branches
+            label: BRANCHES
+            type: object
+            list:
+              min: 1
+              max: 8
+              collapsible:
+                collapsed: true
+                summary: "{meta} / {name}"
+            fields:
+              - { name: meta, label: Meta, type: string }
+              - { name: name, label: Name, type: string }
+              - { name: hook, label: Hook, type: text }
+              - { name: summary, label: Summary, type: text }
+              - { name: status, label: Status, type: string }
+
+      - name: electronic
+        label: 05 / QUARTZ・DIGITAL
+        type: object
+        required: true
+        fields:
+          - { name: chapterNo, label: Chapter No., type: string, readonly: true }
+          - { name: label, label: 章ラベル, type: string, readonly: true }
+          - { name: title, label: 章タイトル, type: string }
+          - { name: indexTitle, label: 目次タイトル, type: string }
+          - { name: teaser, label: 目次・要約, type: text }
+          - name: body
+            label: 本文
+            type: text
+            list: true
+
+      - name: current
+        label: 06 / CURRENT
+        type: object
+        required: true
+        fields:
+          - { name: chapterNo, label: Chapter No., type: string, readonly: true }
+          - { name: storyNo, label: Story No., type: string, readonly: true }
+          - { name: title, label: タイトル, type: string }
+          - { name: name, label: 表示名, type: string }
+          - { name: linkLabel, label: リンク文言, type: string }
+          - { name: href, label: リンク先, type: string, readonly: true }
+
+      - name: sources
+        label: 参考資料・出典
+        type: object
+        required: true
+        fields:
+          - { name: summary, label: 見出し, type: string }
+          - name: items
+            label: 出典
+            type: text
+            list: true


### PR DESCRIPTION
CMS Step 3B.

Scope:
- Add a structured `HISTORY 編集` single-file editor in `.pages.yml` for `src/data/history-content.json`.
- Keep the existing Watches editor unchanged.
- Expose HISTORY copy as structured fields grouped by chapter.
- Keep structural values such as chapter numbers, era labels, CURRENT story number, and smartwatch href readonly where accidental edits would be risky.
- Preserve the current JSON shape exactly; no rendering, CSS, JavaScript, SEO, route, or content changes.

Audit before merge:
- Diff must be limited to `.pages.yml`.
- Configuration follows the current Pages CMS documented `type: file` + `format: json` + nested `object` / list field model.
- Astro build and Verify site output must pass.
- Production live verification must pass after merge.

Note: Pages CMS authentication/GitHub App installation remains an external user-auth step; this PR only makes the repository CMS-ready.