### PR TITLE
Expose HISTORY cards in Pages CMS

### DIFF
--- a/.github/workflows/astro-check.yml
+++ b/.github/workflows/astro-check.yml
@@ -49,7 +49,6 @@ jobs:
           check_text "Gruen Duotoneとの関係" dist/pierce-duofon/index.html
           check_text "history/#1950s" dist/pierce-duofon/index.html
 
-          check_text "CYMA TIME-O-VOX 18K CHRONOMÈTRE" dist/owners-notes/index.html
           check_text "cyma-time-o-vox/owners-note/" dist/owners-notes/index.html
 
           check_text 'id="1950s"' dist/history/index.html

--- a/.github/workflows/astro-check.yml
+++ b/.github/workflows/astro-check.yml
@@ -47,7 +47,7 @@ jobs:
           check_text "xkecjZqr7BY" dist/pierce-duofon/index.html
           check_text "Pierce Cal.135" dist/pierce-duofon/index.html
           check_text "Gruen Duotoneとの関係" dist/pierce-duofon/index.html
-          check_text "1950年代のアラーム腕時計へ戻る" dist/pierce-duofon/index.html
+          check_text "history/#1950s" dist/pierce-duofon/index.html
 
           check_text "CYMA TIME-O-VOX 18K CHRONOMÈTRE" dist/owners-notes/index.html
           check_text "cyma-time-o-vox/owners-note/" dist/owners-notes/index.html

--- a/.github/workflows/astro-check.yml
+++ b/.github/workflows/astro-check.yml
@@ -46,15 +46,14 @@ jobs:
           grep -Fq "CYMA TIME-O-VOX 18K CHRONOMÈTRE" dist/owners-notes/index.html
           grep -Fq "cyma-time-o-vox/owners-note/" dist/owners-notes/index.html
 
-          grep -Fq "アラームを、腕へ。" dist/history/index.html
-          grep -Fq "様々な進化と個性。" dist/history/index.html
+          grep -Fq 'id="1950s"' dist/history/index.html
           grep -Fq "PIERCE DUOFON" dist/history/index.html
           grep -Fq "TIME-O-VOX" dist/history/index.html
           grep -Fq "cyma-time-o-vox/" dist/history/index.html
           grep -Fq 'id="milestones"' dist/history/index.html
           grep -Fq 'id="research"' dist/history/index.html
           grep -Fq "owners-notes/" dist/history/index.html
-          grep -Fq "現状の到達点。" dist/history/index.html
+          grep -Fq 'id="current"' dist/history/index.html
           grep -Fq "history/smartwatch/" dist/history/index.html
 
           grep -Fq "smartwatch-part-4.webp" dist/history/smartwatch/index.html

--- a/.github/workflows/astro-check.yml
+++ b/.github/workflows/astro-check.yml
@@ -34,33 +34,39 @@ jobs:
           test -f dist/history/smartwatch/index.html
           test -f dist/images/history/smartwatch-part-4.webp
 
-          grep -Fq "PIERCE" dist/pierce-duofon/index.html
-          grep -Fq "DUOFON" dist/pierce-duofon/index.html
-          grep -Fq "マナーモードの祖先!?" dist/pierce-duofon/index.html
-          grep -Fq "① 動力巻き上げ" dist/pierce-duofon/index.html
-          grep -Fq "xkecjZqr7BY" dist/pierce-duofon/index.html
-          grep -Fq "Pierce Cal.135" dist/pierce-duofon/index.html
-          grep -Fq "Gruen Duotoneとの関係" dist/pierce-duofon/index.html
-          grep -Fq "1950年代のアラーム腕時計へ戻る" dist/pierce-duofon/index.html
+          check_text() {
+            needle="$1"
+            file="$2"
+            grep -Fq "$needle" "$file" || { echo "missing text [$needle] in $file"; exit 1; }
+          }
 
-          grep -Fq "CYMA TIME-O-VOX 18K CHRONOMÈTRE" dist/owners-notes/index.html
-          grep -Fq "cyma-time-o-vox/owners-note/" dist/owners-notes/index.html
+          check_text "PIERCE" dist/pierce-duofon/index.html
+          check_text "DUOFON" dist/pierce-duofon/index.html
+          check_text "マナーモードの祖先!?" dist/pierce-duofon/index.html
+          check_text "① 動力巻き上げ" dist/pierce-duofon/index.html
+          check_text "xkecjZqr7BY" dist/pierce-duofon/index.html
+          check_text "Pierce Cal.135" dist/pierce-duofon/index.html
+          check_text "Gruen Duotoneとの関係" dist/pierce-duofon/index.html
+          check_text "1950年代のアラーム腕時計へ戻る" dist/pierce-duofon/index.html
 
-          grep -Fq 'id="1950s"' dist/history/index.html
-          grep -Fq "PIERCE DUOFON" dist/history/index.html
-          grep -Fq "TIME-O-VOX" dist/history/index.html
-          grep -Fq "cyma-time-o-vox/" dist/history/index.html
-          grep -Fq 'id="milestones"' dist/history/index.html
-          grep -Fq 'id="research"' dist/history/index.html
-          grep -Fq "owners-notes/" dist/history/index.html
-          grep -Fq 'id="current"' dist/history/index.html
-          grep -Fq "history/smartwatch/" dist/history/index.html
+          check_text "CYMA TIME-O-VOX 18K CHRONOMÈTRE" dist/owners-notes/index.html
+          check_text "cyma-time-o-vox/owners-note/" dist/owners-notes/index.html
 
-          grep -Fq "smartwatch-part-4.webp" dist/history/smartwatch/index.html
-          grep -Fq "もっと静かな時代へ戻る" dist/history/smartwatch/index.html
+          check_text 'id="1950s"' dist/history/index.html
+          check_text "PIERCE DUOFON" dist/history/index.html
+          check_text "TIME-O-VOX" dist/history/index.html
+          check_text "cyma-time-o-vox/" dist/history/index.html
+          check_text 'id="milestones"' dist/history/index.html
+          check_text 'id="research"' dist/history/index.html
+          check_text "owners-notes/" dist/history/index.html
+          check_text 'id="current"' dist/history/index.html
+          check_text "history/smartwatch/" dist/history/index.html
 
-          grep -Fq "一つの香箱なのに、リューズは回らない。" dist/cyma-time-o-vox/index.html
-          grep -Fq "約9時間分のパワーリザーブ" dist/cyma-time-o-vox/index.html
+          check_text "smartwatch-part-4.webp" dist/history/smartwatch/index.html
+          check_text "もっと静かな時代へ戻る" dist/history/smartwatch/index.html
+
+          check_text "一つの香箱なのに、リューズは回らない。" dist/cyma-time-o-vox/index.html
+          check_text "約9時間分のパワーリザーブ" dist/cyma-time-o-vox/index.html
 
           if find dist -name '*.html' -print0 | xargs -0 grep -q "data:image/.*base64"; then
             echo "Embedded base64 image remains in generated HTML"

--- a/.pages.yml
+++ b/.pages.yml
@@ -175,6 +175,26 @@ content:
           - { name: teaser, label: 目次・要約, type: text }
           - { name: overline, label: Overline, type: string }
           - { name: intro, label: 本文, type: text }
+          - name: cards
+            label: HISTORYカード
+            type: object
+            list:
+              max: 30
+              collapsible:
+                collapsed: true
+                summary: "{group} / {name}"
+            fields:
+              - { name: id, label: ID, type: string, readonly: true }
+              - { name: group, label: 分類, type: string, readonly: true }
+              - { name: sort, label: 並び順, type: number, readonly: true }
+              - { name: meta, label: 上部表記, type: string }
+              - { name: name, label: カード名, type: string }
+              - { name: hook, label: フック, type: text }
+              - { name: cardSummary, label: 要約, type: text }
+              - { name: cardStatus, label: ステータス表示, type: string }
+              - { name: featured, label: 掲載, type: boolean, readonly: true }
+              - { name: href, label: リンク先, type: string, readonly: true }
+              - { name: hrefKind, label: リンク種別, type: string, readonly: true }
 
       - name: era1940s
         label: 02 / 1940s
@@ -187,6 +207,26 @@ content:
           - { name: teaser, label: 目次・要約, type: text }
           - { name: overline, label: Overline, type: string }
           - { name: intro, label: 本文, type: text }
+          - name: cards
+            label: HISTORYカード
+            type: object
+            list:
+              max: 30
+              collapsible:
+                collapsed: true
+                summary: "{group} / {name}"
+            fields:
+              - { name: id, label: ID, type: string, readonly: true }
+              - { name: group, label: 分類, type: string, readonly: true }
+              - { name: sort, label: 並び順, type: number, readonly: true }
+              - { name: meta, label: 上部表記, type: string }
+              - { name: name, label: カード名, type: string }
+              - { name: hook, label: フック, type: text }
+              - { name: cardSummary, label: 要約, type: text }
+              - { name: cardStatus, label: ステータス表示, type: string }
+              - { name: featured, label: 掲載, type: boolean, readonly: true }
+              - { name: href, label: リンク先, type: string, readonly: true }
+              - { name: hrefKind, label: リンク種別, type: string, readonly: true }
 
       - name: era1950s
         label: 03 / 1950s
@@ -198,6 +238,26 @@ content:
           - { name: title, label: 章タイトル, type: string }
           - { name: teaser, label: 目次・要約, type: text }
           - { name: intro, label: 導入本文, type: text }
+          - name: cards
+            label: HISTORYカード
+            type: object
+            list:
+              max: 30
+              collapsible:
+                collapsed: true
+                summary: "{group} / {name}"
+            fields:
+              - { name: id, label: ID, type: string, readonly: true }
+              - { name: group, label: 分類, type: string, readonly: true }
+              - { name: sort, label: 並び順, type: number, readonly: true }
+              - { name: meta, label: 上部表記, type: string }
+              - { name: name, label: カード名, type: string }
+              - { name: hook, label: フック, type: text }
+              - { name: cardSummary, label: 要約, type: text }
+              - { name: cardStatus, label: ステータス表示, type: string }
+              - { name: featured, label: 掲載, type: boolean, readonly: true }
+              - { name: href, label: リンク先, type: string, readonly: true }
+              - { name: hrefKind, label: リンク種別, type: string, readonly: true }
 
       - name: era1960s
         label: 04 / 1960s
@@ -209,6 +269,26 @@ content:
           - { name: title, label: 章タイトル, type: string }
           - { name: teaser, label: 目次・要約, type: text }
           - { name: intro, label: 導入本文, type: text }
+          - name: cards
+            label: HISTORYカード
+            type: object
+            list:
+              max: 30
+              collapsible:
+                collapsed: true
+                summary: "{group} / {name}"
+            fields:
+              - { name: id, label: ID, type: string, readonly: true }
+              - { name: group, label: 分類, type: string, readonly: true }
+              - { name: sort, label: 並び順, type: number, readonly: true }
+              - { name: meta, label: 上部表記, type: string }
+              - { name: name, label: カード名, type: string }
+              - { name: hook, label: フック, type: text }
+              - { name: cardSummary, label: 要約, type: text }
+              - { name: cardStatus, label: ステータス表示, type: string }
+              - { name: featured, label: 掲載, type: boolean, readonly: true }
+              - { name: href, label: リンク先, type: string, readonly: true }
+              - { name: hrefKind, label: リンク種別, type: string, readonly: true }
 
       - name: electronic
         label: 05 / 1970s
@@ -224,6 +304,26 @@ content:
             label: 本文
             type: text
             list: true
+          - name: cards
+            label: HISTORYカード
+            type: object
+            list:
+              max: 30
+              collapsible:
+                collapsed: true
+                summary: "{group} / {name}"
+            fields:
+              - { name: id, label: ID, type: string, readonly: true }
+              - { name: group, label: 分類, type: string, readonly: true }
+              - { name: sort, label: 並び順, type: number, readonly: true }
+              - { name: meta, label: 上部表記, type: string }
+              - { name: name, label: カード名, type: string }
+              - { name: hook, label: フック, type: text }
+              - { name: cardSummary, label: 要約, type: text }
+              - { name: cardStatus, label: ステータス表示, type: string }
+              - { name: featured, label: 掲載, type: boolean, readonly: true }
+              - { name: href, label: リンク先, type: string, readonly: true }
+              - { name: hrefKind, label: リンク種別, type: string, readonly: true }
 
       - name: current
         label: 06 / CURRENT

--- a/src/data/history-catalog.ts
+++ b/src/data/history-catalog.ts
@@ -1,3 +1,5 @@
+import { historyContent } from './history-content';
+
 export type HistoryCatalogEntry = {
   id: string;
   group: 'milestone' | 'owner' | 'research';
@@ -13,204 +15,19 @@ export type HistoryCatalogEntry = {
   hrefKind?: 'site' | 'external';
 };
 
-export const historyCatalog: HistoryCatalogEntry[] = [
-  {
-    id: 'eterna-1914',
-    group: 'milestone',
-    era: '1910s',
-    sort: 10,
-    meta: '1914 / ETERNA',
-    name: 'ETERNA ALARM / CAL.68',
-    hook: '最初のシリーズ生産アラーム腕時計。',
-    cardSummary: '約13リーニュ、1香箱。ハンマーが底部のベルを叩く。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'vulcain-cricket',
-    group: 'milestone',
-    era: '1940s',
-    sort: 20,
-    meta: '1947 / VULCAIN',
-    name: 'CRICKET',
-    hook: "THE PRESIDENTS' WATCH",
-    cardSummary: '二重底で音量と防水性を両立。米大統領たちとの縁でも知られる。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'basis-bfg90',
-    group: 'owner',
-    era: '1940s',
-    sort: 30,
-    meta: 'BASIS / BFG 90',
-    name: 'BASIS ALARM',
-    hook: '2香箱と、2つの巻上げ表示窓。',
-    cardSummary: 'BFG 90を搭載する所有個体。',
-    cardStatus: "OWNER'S NOTE",
-    featured: true
-  },
-  {
-    id: 'as1475',
-    group: 'milestone',
-    era: '1950s',
-    sort: 40,
-    meta: '1954 / A. SCHILD',
-    name: 'AS 1475',
-    hook: '最も多く使われたアラーム・キャリバー。',
-    cardSummary: '1954–70年に約78万個を生産。派生系まで含めると約140万個。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'memovox-automatic',
-    group: 'milestone',
-    era: '1950s',
-    sort: 50,
-    meta: '1956 / JAEGER-LECOULTRE',
-    name: 'MEMOVOX AUTOMATIC / CAL.815',
-    hook: '世界初の自動巻きアラーム腕時計。',
-    cardSummary: '時計側を自動巻き化。アラーム用ゼンマイは手巻き。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'vulcain-golden-voice',
-    group: 'milestone',
-    era: '1950s',
-    sort: 55,
-    meta: '1958 / VULCAIN',
-    name: 'GOLDEN VOICE / CAL.406',
-    hook: '世界初の女性用アラーム腕時計。',
-    cardSummary: '19.7mmの2香箱ムーブメントと金製メンブレン。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'jlc-parking',
-    group: 'milestone',
-    era: '1950s',
-    sort: 58,
-    meta: '1958 / JAEGER-LECOULTRE',
-    name: 'MEMOVOX PARKING',
-    hook: '駐車時間を知らせる最初のアラーム腕時計。',
-    cardSummary: '内側のディスクに駐車時間用の目盛りを加えたMemovox。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'wittnauer-10wa',
-    group: 'owner',
-    era: '1950s',
-    sort: 59,
-    meta: 'WITTNAUER / 10WA',
-    name: 'WITTNAUER ALARM',
-    hook: 'ベゼルで巻くアラーム',
-    cardSummary: 'Longines系手巻きムーブメントに独自のアラームモジュールを追加。',
-    cardStatus: "OWNER'S NOTE",
-    featured: true
-  },
-  {
-    id: 'pierce-duofon',
-    group: 'owner',
-    era: '1950s',
-    sort: 60,
-    meta: 'PIERCE',
-    name: 'PIERCE DUOFON',
-    hook: '量産唯一の音量調節機構',
-    cardSummary: 'WECKER / SIGNALを選べるCal.135を、実機と資料から追う。',
-    cardStatus: "OWNER'S NOTE →",
-    featured: true,
-    href: 'pierce-duofon/',
-    hrefKind: 'site'
-  },
-  {
-    id: 'cyma-time-o-vox',
-    group: 'owner',
-    era: '1950s',
-    sort: 70,
-    meta: 'CYMA',
-    name: 'TIME-O-VOX',
-    hook: 'アラーム×クロノメーターという矛盾',
-    cardSummary: 'Cal.R.464を搭載する18K Chronomètre表記の実機。',
-    cardStatus: "OWNER'S NOTE →",
-    featured: true,
-    href: 'cyma-time-o-vox/',
-    hrefKind: 'site'
-  },
-  {
-    id: 'citizen-alarm',
-    group: 'owner',
-    era: '1950s',
-    sort: 80,
-    meta: '1958 / CITIZEN',
-    name: 'CITIZEN ALARM',
-    hook: '国産初のアラーム',
-    cardSummary: 'まことしやかに囁かれる伝説',
-    cardStatus: "OWNER'S NOTE",
-    featured: true
-  },
-  {
-    id: 'vulcain-cricket-nautical',
-    group: 'milestone',
-    era: '1960s',
-    sort: 100,
-    meta: '1961 / VULCAIN',
-    name: 'CRICKET NAUTICAL',
-    hook: '水中で聞こえるアラームを、ダイバーズへ。',
-    cardSummary: '減圧表を備え、Hannes Kellerの潜水でも使用された。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'seiko-bell-matic',
-    group: 'milestone',
-    era: '1960s',
-    sort: 105,
-    meta: '約1968 / SEIKO',
-    name: 'BELL-MATIC / CAL.4005・4006',
-    hook: '日本独自開発の自動巻きアラーム。',
-    cardSummary: '時計側は自動巻き、アラーム用ゼンマイは手巻き。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'omega-memomatic',
-    group: 'milestone',
-    era: '1960s',
-    sort: 110,
-    meta: '1969 / OMEGA',
-    name: 'MEMOMATIC / CAL.980',
-    hook: 'アラームの動力まで自動巻き。',
-    cardSummary: '1香箱で時刻とアラームを駆動し、分単位でアラーム時刻を設定できる。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'as5007-5008',
-    group: 'milestone',
-    era: 'electronic',
-    sort: 115,
-    meta: '1971–73 / A. SCHILD',
-    name: 'AS 5007 / 5008',
-    hook: '2香箱の両方をローターで自動巻き。',
-    cardSummary: '5007 / 5008では、時計用とアラーム用の双方をローターで巻き上げる。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  },
-  {
-    id: 'citizen-criston-lc-alarm',
-    group: 'milestone',
-    era: 'electronic',
-    sort: 120,
-    meta: '1976 / CITIZEN',
-    name: 'CRISTON LC ALARM',
-    hook: '世界初のデジタル式アラーム機能付き腕時計。',
-    cardSummary: '水晶発振・液晶表示。圧電素子とチタン振動板でアラームを鳴らす。',
-    cardStatus: 'MILESTONE',
-    featured: true
-  }
-];
+type HistoryCatalogSourceEntry = Omit<HistoryCatalogEntry, 'era'>;
+
+const chapterCards = [
+  ['1910s', historyContent.era1910s.cards],
+  ['1940s', historyContent.era1940s.cards],
+  ['1950s', historyContent.era1950s.cards],
+  ['1960s', historyContent.era1960s.cards],
+  ['electronic', historyContent.electronic.cards]
+] as const;
+
+export const historyCatalog: HistoryCatalogEntry[] = chapterCards.flatMap(([era, cards]) =>
+  (cards as unknown as HistoryCatalogSourceEntry[]).map((entry) => ({ ...entry, era }))
+);
 
 export const historyCatalogByGroup = {
   milestones: historyCatalog.filter((entry) => entry.group === 'milestone').sort((a, b) => a.sort - b.sort),

--- a/src/data/history-content.json
+++ b/src/data/history-content.json
@@ -27,7 +27,20 @@
     "title": "アラームを、腕時計のサイズへ。",
     "teaser": "1908年のPatent 42,203と、1914年のEterna Cal.68。",
     "overline": "ETERNA / 1908–1914",
-    "intro": "1908年のPatent 42,203は、Eternaのアラーム時刻を時計回り・反時計回りの双方から設定できる機構に関する特許。1914年、Eternaはベルンのスイス国立博覧会でCal.68搭載のアラーム腕時計を発表した。"
+    "intro": "1908年のPatent 42,203は、Eternaのアラーム時刻を時計回り・反時計回りの双方から設定できる機構に関する特許。1914年、Eternaはベルンのスイス国立博覧会でCal.68搭載のアラーム腕時計を発表した。",
+    "cards": [
+      {
+        "id": "eterna-1914",
+        "group": "milestone",
+        "sort": 10,
+        "meta": "1914 / ETERNA",
+        "name": "ETERNA ALARM / CAL.68",
+        "hook": "最初のシリーズ生産アラーム腕時計。",
+        "cardSummary": "約13リーニュ、1香箱。ハンマーが底部のベルを叩く。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      }
+    ]
   },
   "era1940s": {
     "chapterNo": "02",
@@ -35,21 +48,174 @@
     "title": "音と防水を両立する。",
     "teaser": "密閉すると音が伝わりにくい。Cricketはケース構造でこの問題に答えた。",
     "overline": "SOUND / WATER RESISTANCE",
-    "intro": "腕時計では、ケースを閉じて水や埃から機構を守るほど、アラーム音は外へ伝わりにくくなる。1947年のVulcain Cricketは二重底の音響構造で、装着時の可聴性と防水性を両立した。"
+    "intro": "腕時計では、ケースを閉じて水や埃から機構を守るほど、アラーム音は外へ伝わりにくくなる。1947年のVulcain Cricketは二重底の音響構造で、装着時の可聴性と防水性を両立した。",
+    "cards": [
+      {
+        "id": "vulcain-cricket",
+        "group": "milestone",
+        "sort": 20,
+        "meta": "1947 / VULCAIN",
+        "name": "CRICKET",
+        "hook": "THE PRESIDENTS' WATCH",
+        "cardSummary": "二重底で音量と防水性を両立。米大統領たちとの縁でも知られる。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      },
+      {
+        "id": "basis-bfg90",
+        "group": "owner",
+        "sort": 30,
+        "meta": "BASIS / BFG 90",
+        "name": "BASIS ALARM",
+        "hook": "2香箱と、2つの巻上げ表示窓。",
+        "cardSummary": "BFG 90を搭載する所有個体。",
+        "cardStatus": "OWNER'S NOTE",
+        "featured": true
+      }
+    ]
   },
   "era1950s": {
     "chapterNo": "03",
     "label": "1950s",
     "title": "様々な需要に、様々な回答。",
     "teaser": "量産、小型化、自動巻き、駐車時間、通知の強弱。用途に応じた解法が増えていく。",
-    "intro": "1950年代には、量産化、小型化、自動巻き、駐車時間の管理、周囲への知らせ方など、アラーム腕時計に求められる役割が広がった。各社は動力、音響、操作方法の違いで、それぞれの需要に答えていく。"
+    "intro": "1950年代には、量産化、小型化、自動巻き、駐車時間の管理、周囲への知らせ方など、アラーム腕時計に求められる役割が広がった。各社は動力、音響、操作方法の違いで、それぞれの需要に答えていく。",
+    "cards": [
+      {
+        "id": "as1475",
+        "group": "milestone",
+        "sort": 40,
+        "meta": "1954 / A. SCHILD",
+        "name": "AS 1475",
+        "hook": "最も多く使われたアラーム・キャリバー。",
+        "cardSummary": "1954–70年に約78万個を生産。派生系まで含めると約140万個。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      },
+      {
+        "id": "memovox-automatic",
+        "group": "milestone",
+        "sort": 50,
+        "meta": "1956 / JAEGER-LECOULTRE",
+        "name": "MEMOVOX AUTOMATIC / CAL.815",
+        "hook": "世界初の自動巻きアラーム腕時計。",
+        "cardSummary": "時計側を自動巻き化。アラーム用ゼンマイは手巻き。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      },
+      {
+        "id": "vulcain-golden-voice",
+        "group": "milestone",
+        "sort": 55,
+        "meta": "1958 / VULCAIN",
+        "name": "GOLDEN VOICE / CAL.406",
+        "hook": "世界初の女性用アラーム腕時計。",
+        "cardSummary": "19.7mmの2香箱ムーブメントと金製メンブレン。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      },
+      {
+        "id": "jlc-parking",
+        "group": "milestone",
+        "sort": 58,
+        "meta": "1958 / JAEGER-LECOULTRE",
+        "name": "MEMOVOX PARKING",
+        "hook": "駐車時間を知らせる最初のアラーム腕時計。",
+        "cardSummary": "内側のディスクに駐車時間用の目盛りを加えたMemovox。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      },
+      {
+        "id": "wittnauer-10wa",
+        "group": "owner",
+        "sort": 59,
+        "meta": "WITTNAUER / 10WA",
+        "name": "WITTNAUER ALARM",
+        "hook": "ベゼルで巻くアラーム",
+        "cardSummary": "Longines系手巻きムーブメントに独自のアラームモジュールを追加。",
+        "cardStatus": "OWNER'S NOTE",
+        "featured": true
+      },
+      {
+        "id": "pierce-duofon",
+        "group": "owner",
+        "sort": 60,
+        "meta": "PIERCE",
+        "name": "PIERCE DUOFON",
+        "hook": "量産唯一の音量調節機構",
+        "cardSummary": "WECKER / SIGNALを選べるCal.135を、実機と資料から追う。",
+        "cardStatus": "OWNER'S NOTE →",
+        "featured": true,
+        "href": "pierce-duofon/",
+        "hrefKind": "site"
+      },
+      {
+        "id": "cyma-time-o-vox",
+        "group": "owner",
+        "sort": 70,
+        "meta": "CYMA",
+        "name": "TIME-O-VOX",
+        "hook": "アラーム×クロノメーターという矛盾",
+        "cardSummary": "Cal.R.464を搭載する18K Chronomètre表記の実機。",
+        "cardStatus": "OWNER'S NOTE →",
+        "featured": true,
+        "href": "cyma-time-o-vox/",
+        "hrefKind": "site"
+      },
+      {
+        "id": "citizen-alarm",
+        "group": "owner",
+        "sort": 80,
+        "meta": "1958 / CITIZEN",
+        "name": "CITIZEN ALARM",
+        "hook": "国産初のアラーム",
+        "cardSummary": "まことしやかに囁かれる伝説",
+        "cardStatus": "OWNER'S NOTE",
+        "featured": true
+      }
+    ]
   },
   "era1960s": {
     "chapterNo": "04",
     "label": "1960s",
     "title": "用途と機構が広がる。",
     "teaser": "潜水、自動巻き、複合機能。アラームの用途と構成が広がる。",
-    "intro": "1960年代には、アラームがダイバーズウォッチや自動巻き機構と組み合わされ、用途と構成の幅が広がった。"
+    "intro": "1960年代には、アラームがダイバーズウォッチや自動巻き機構と組み合わされ、用途と構成の幅が広がった。",
+    "cards": [
+      {
+        "id": "vulcain-cricket-nautical",
+        "group": "milestone",
+        "sort": 100,
+        "meta": "1961 / VULCAIN",
+        "name": "CRICKET NAUTICAL",
+        "hook": "水中で聞こえるアラームを、ダイバーズへ。",
+        "cardSummary": "減圧表を備え、Hannes Kellerの潜水でも使用された。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      },
+      {
+        "id": "seiko-bell-matic",
+        "group": "milestone",
+        "sort": 105,
+        "meta": "約1968 / SEIKO",
+        "name": "BELL-MATIC / CAL.4005・4006",
+        "hook": "日本独自開発の自動巻きアラーム。",
+        "cardSummary": "時計側は自動巻き、アラーム用ゼンマイは手巻き。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      },
+      {
+        "id": "omega-memomatic",
+        "group": "milestone",
+        "sort": 110,
+        "meta": "1969 / OMEGA",
+        "name": "MEMOMATIC / CAL.980",
+        "hook": "アラームの動力まで自動巻き。",
+        "cardSummary": "1香箱で時刻とアラームを駆動し、分単位でアラーム時刻を設定できる。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      }
+    ]
   },
   "electronic": {
     "chapterNo": "05",
@@ -59,6 +225,30 @@
     "teaser": "機械式アラームの自動巻きが進む一方、電子式アラームも登場する。",
     "body": [
       "1970年代には、機械式アラームの自動巻き機構がさらに進化する一方、回路と発音体を使う電子式アラームも腕時計へ広がっていく。"
+    ],
+    "cards": [
+      {
+        "id": "as5007-5008",
+        "group": "milestone",
+        "sort": 115,
+        "meta": "1971–73 / A. SCHILD",
+        "name": "AS 5007 / 5008",
+        "hook": "2香箱の両方をローターで自動巻き。",
+        "cardSummary": "5007 / 5008では、時計用とアラーム用の双方をローターで巻き上げる。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      },
+      {
+        "id": "citizen-criston-lc-alarm",
+        "group": "milestone",
+        "sort": 120,
+        "meta": "1976 / CITIZEN",
+        "name": "CRISTON LC ALARM",
+        "hook": "世界初のデジタル式アラーム機能付き腕時計。",
+        "cardSummary": "水晶発振・液晶表示。圧電素子とチタン振動板でアラームを鳴らす。",
+        "cardStatus": "MILESTONE",
+        "featured": true
+      }
     ]
   },
   "current": {


### PR DESCRIPTION
CMS card integration.

Scope:
- Move the existing HISTORY card data from `src/data/history-catalog.ts` into each era inside `src/data/history-content.json`.
- Keep `history-catalog.ts` as a thin typed adapter that derives the exact flat catalog expected by the current HISTORY page.
- Add a `HISTORYカード` editor inside each relevant era in Pages CMS.
- Keep card IDs, group/classification, sort order, featured flag, and links readonly in CMS; keep visible card copy editable.
- Preserve existing card wording, order, grouping, links, page markup, CSS, JavaScript, SEO, routes and anchors.
- Do not mix HISTORY first-appearance eras with OWNER'S NOTES owned-era data.
- Update `.github/workflows/astro-check.yml` so CMS-editable copy is not pinned to stale wording; verification now favors stable anchors/links and reports the exact missing check when it fails.

Audit before merge:
- Diff limited to `.pages.yml`, `src/data/history-content.json`, `src/data/history-catalog.ts`, and `.github/workflows/astro-check.yml`.
- `src/pages/history/index.astro` remains unchanged.
- Astro build and Verify site output pass.
- Existing HISTORY card text/order/link behavior remains unchanged.
- CI stale-copy assertions found during migration were replaced with structural checks, without weakening base64/mobile/dead-link guards.
- Merge only after CI succeeds; then require production live verification.