### PR TITLE
Add CMS-friendly watch media fields

### DIFF
--- a/.github/workflows/astro-check.yml
+++ b/.github/workflows/astro-check.yml
@@ -48,7 +48,7 @@ jobs:
           check_text "DUOFON" dist/pierce-duofon/index.html
           check_text "マナーモードの祖先!?" dist/pierce-duofon/index.html
           check_text "① 動力巻き上げ" dist/pierce-duofon/index.html
-          check_text "xkecjZqr7BY" dist/pierce-duofon/index.html
+          check_text "youtube.com/embed/xkecjZqr7BY" dist/pierce-duofon/index.html
           check_text "Pierce Cal.135" dist/pierce-duofon/index.html
           check_text "Gruen Duotoneとの関係" dist/pierce-duofon/index.html
           check_text "history/#1950s" dist/pierce-duofon/index.html
@@ -72,6 +72,8 @@ jobs:
           check_text "約9時間分のパワーリザーブ" dist/cyma-time-o-vox/index.html
           check_text "Cyma timeovox .png" dist/cyma-time-o-vox/index.html
           check_text "Cyma timeovox .png" dist/cyma-time-o-vox/owners-note/index.html
+          check_text "youtube.com/embed/OONH0JZqCK0" dist/cyma-time-o-vox/index.html
+          check_text "2085277918473883977" dist/cyma-time-o-vox/index.html
 
           if find dist -name '*.html' -print0 | xargs -0 grep -q "data:image/.*base64"; then
             echo "Embedded base64 image remains in generated HTML"

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -81,11 +81,14 @@ jobs:
           check_text 'pierce-duofon/#owners-note' dist/owners-notes/index.html
           check_text 'smartwatch-part-4.webp' dist/history/smartwatch/index.html
           check_text 'もっと静かな時代へ戻る' dist/history/smartwatch/index.html
+          check_text 'youtube.com/embed/xkecjZqr7BY' dist/pierce-duofon/index.html
           check_text '一つの香箱なのに、リューズは回らない。' dist/cyma-time-o-vox/index.html
           check_text '6〜10秒' dist/cyma-time-o-vox/index.html
           check_text '約9時間分のパワーリザーブ' dist/cyma-time-o-vox/index.html
           check_text 'Cyma timeovox .png' dist/cyma-time-o-vox/index.html
           check_text 'Cyma timeovox .png' dist/cyma-time-o-vox/owners-note/index.html
+          check_text 'youtube.com/embed/OONH0JZqCK0' dist/cyma-time-o-vox/index.html
+          check_text '2085277918473883977' dist/cyma-time-o-vox/index.html
           check_text 'owners-notes' dist/sitemap.xml
           check_text 'cyma-time-o-vox' dist/sitemap.xml
           if grep -Fq '個体ページへ' dist/owners-notes/index.html; then
@@ -118,6 +121,7 @@ jobs:
           history="${root}history/"
           owners="${root}owners-notes/"
           smart="${root}history/smartwatch/"
+          duofon="${root}pierce-duofon/"
           cyma="${root}cyma-time-o-vox/"
           cyma_note="${root}cyma-time-o-vox/owners-note/"
           for attempt in {1..12}; do
@@ -125,6 +129,7 @@ jobs:
             history_html=$(curl -fsSL "$history" || true)
             owners_html=$(curl -fsSL "$owners" || true)
             smart_html=$(curl -fsSL "$smart" || true)
+            duofon_html=$(curl -fsSL "$duofon" || true)
             cyma_html=$(curl -fsSL "$cyma" || true)
             cyma_note_html=$(curl -fsSL "$cyma_note" || true)
             parts_ok=1
@@ -150,15 +155,18 @@ jobs:
               && ! grep -Fq "個体ページへ" <<<"$owners_html" \
               && grep -Fq "smartwatch-part-4.webp" <<<"$smart_html" \
               && grep -Fq "もっと静かな時代へ戻る" <<<"$smart_html" \
+              && grep -Fq "youtube.com/embed/xkecjZqr7BY" <<<"$duofon_html" \
               && grep -Fq "一つの香箱なのに、リューズは回らない。" <<<"$cyma_html" \
               && grep -Fq "約9時間分のパワーリザーブ" <<<"$cyma_html" \
               && grep -Fq "Cyma timeovox .png" <<<"$cyma_html" \
               && grep -Fq "Cyma timeovox .png" <<<"$cyma_note_html" \
+              && grep -Fq "youtube.com/embed/OONH0JZqCK0" <<<"$cyma_html" \
+              && grep -Fq "2085277918473883977" <<<"$cyma_html" \
               && ! grep -Fq "#index-milestones" <<<"$home_html$history_html" \
               && ! grep -Fq "#index-owners" <<<"$home_html$history_html" \
               && ! grep -Fq "#index-interests" <<<"$home_html$history_html" \
               && [ "$parts_ok" -eq 1 ]; then
-              echo "Verified live navigation, owners notes, smartwatch artwork, and Cyma page: $root"
+              echo "Verified live navigation, watch videos, owners notes, smartwatch artwork, and Cyma page: $root"
               exit 0
             fi
             sleep 5

--- a/.pages.yml
+++ b/.pages.yml
@@ -76,7 +76,7 @@ content:
         label: 実機鳴動
         type: object
         fields:
-          - { name: youtubeId, label: YouTube ID, type: string }
+          - { name: youtubeId, label: YouTube URL / ID, type: string }
           - { name: xUrl, label: Original post on X, type: string }
       - name: deepDive
         label: DEEP DIVE
@@ -95,6 +95,18 @@ content:
             label: Paragraphs
             type: text
             list: true
+          - name: images
+            label: 補足画像
+            type: object
+            list:
+              max: 8
+              collapsible:
+                collapsed: true
+                summary: "{caption}"
+            fields:
+              - { name: src, label: 画像, type: image, required: true }
+              - { name: caption, label: キャプション, type: text }
+              - { name: alt, label: altテキスト, type: string }
       - name: sources
         label: 参考資料・出典
         type: string

--- a/src/components/AlarmVideo.astro
+++ b/src/components/AlarmVideo.astro
@@ -1,6 +1,30 @@
 ---
 const { video, title } = Astro.props;
-const embed = `https://www.youtube.com/embed/${video.youtubeId}`;
+
+const getYouTubeId = (value: string) => {
+  const input = value?.trim();
+  if (!input) return '';
+  if (!input.includes('/') && !input.includes('.')) return input;
+
+  try {
+    const url = new URL(input);
+    const host = url.hostname.replace(/^www\./, '');
+    if (host === 'youtu.be') return url.pathname.split('/').filter(Boolean)[0] ?? '';
+    if (host === 'youtube.com' || host === 'm.youtube.com') {
+      const queryId = url.searchParams.get('v');
+      if (queryId) return queryId;
+      const parts = url.pathname.split('/').filter(Boolean);
+      if (['shorts', 'embed', 'live'].includes(parts[0])) return parts[1] ?? '';
+    }
+  } catch {
+    return input;
+  }
+
+  return input;
+};
+
+const youtubeId = getYouTubeId(video.youtubeId);
+const embed = `https://www.youtube.com/embed/${youtubeId}`;
 ---
 <section class="section shell" aria-labelledby="listen">
   <h2 id="listen">実機鳴動</h2>

--- a/src/components/DeepDive.astro
+++ b/src/components/DeepDive.astro
@@ -1,5 +1,9 @@
 ---
 const { items } = Astro.props;
+const base = import.meta.env.BASE_URL;
+const resolveImage = (path: string) => /^https?:\/\//.test(path)
+  ? path
+  : `${base}${path.replace(/^\//, '')}`;
 ---
 <section class="section shell" aria-labelledby="deep">
   <h2 id="deep">さらに詳しく</h2>
@@ -10,8 +14,30 @@ const { items } = Astro.props;
         <div class="copy prose">
           {item.subtitle && <h3>{item.subtitle}</h3>}
           {item.paragraphs.map((paragraph: string) => <p>{paragraph}</p>)}
+          {item.images?.length > 0 && (
+            <div class="deep-media">
+              {item.images.map((image: any) => (
+                <figure>
+                  <img
+                    src={resolveImage(image.src)}
+                    alt={image.alt || image.caption || `${item.title} 補足画像`}
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  {image.caption && <figcaption>{image.caption}</figcaption>}
+                </figure>
+              ))}
+            </div>
+          )}
         </div>
       </details>
     ))}
   </div>
 </section>
+
+<style>
+  .deep-media{display:grid;gap:18px;margin-top:24px}
+  .deep-media figure{margin:0}
+  .deep-media img{display:block;width:100%;height:auto}
+  .deep-media figcaption{margin-top:8px;font-size:13px;line-height:1.7;opacity:.72}
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -39,7 +39,12 @@ const watches = defineCollection({
       number: z.string(),
       title: z.string(),
       subtitle: z.string().optional(),
-      paragraphs: z.array(z.string())
+      paragraphs: z.array(z.string()),
+      images: z.array(z.object({
+        src: z.string(),
+        caption: z.string().optional(),
+        alt: z.string().optional()
+      })).optional()
     })),
     sources: z.array(z.string())
   })


### PR DESCRIPTION
Make watch video fields accept either a raw YouTube ID or a full YouTube/Shorts URL, preserving existing Duofon data while allowing CYMA's CMS-pasted URL. Add optional per-section DEEP DIVE reference images with image/caption/alt fields in Pages CMS and shared rendering support. Extend CI/live verification for Duofon and CYMA embeds. No watch copy or OWNER'S NOTE text changes.