### PR TITLE
Fix CYMA CMS catch and deep-dive media placement

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -31,7 +31,7 @@ content:
         label: Catch
         type: string
         list:
-          min: 2
+          min: 1
           max: 2
       - name: ownersNote
         label: OWNER'S NOTE
@@ -107,6 +107,7 @@ content:
               - { name: src, label: 画像, type: image, required: true }
               - { name: caption, label: キャプション, type: text }
               - { name: alt, label: altテキスト, type: string }
+              - { name: afterParagraph, label: 何段落目の後に表示, type: number }
       - name: sources
         label: 参考資料・出典
         type: string

--- a/src/components/DeepDive.astro
+++ b/src/components/DeepDive.astro
@@ -8,36 +8,71 @@ const resolveImage = (path: string) => /^https?:\/\//.test(path)
 <section class="section shell" aria-labelledby="deep">
   <h2 id="deep">さらに詳しく</h2>
   <div class="deep-list">
-    {items.map((item: any) => (
-      <details>
-        <summary><span class="number">{item.number}</span><span class="summary-label">{item.title}</span></summary>
-        <div class="copy prose">
-          {item.subtitle && <h3>{item.subtitle}</h3>}
-          {item.paragraphs.map((paragraph: string) => <p>{paragraph}</p>)}
-          {item.images?.length > 0 && (
-            <div class="deep-media">
-              {item.images.map((image: any) => (
-                <figure>
-                  <img
-                    src={resolveImage(image.src)}
-                    alt={image.alt || image.caption || `${item.title} 補足画像`}
-                    loading="lazy"
-                    decoding="async"
-                  />
-                  {image.caption && <figcaption>{image.caption}</figcaption>}
-                </figure>
-              ))}
-            </div>
-          )}
-        </div>
-      </details>
-    ))}
+    {items.map((item: any) => {
+      const images = item.images ?? [];
+      const trailingImages = images.filter((image: any) =>
+        !Number.isInteger(image.afterParagraph)
+        || image.afterParagraph < 1
+        || image.afterParagraph > item.paragraphs.length
+      );
+
+      return (
+        <details>
+          <summary><span class="number">{item.number}</span><span class="summary-label">{item.title}</span></summary>
+          <div class="copy prose">
+            {item.subtitle && <h3>{item.subtitle}</h3>}
+            {item.paragraphs.map((paragraph: string, index: number) => {
+              const imagesAfter = images.filter((image: any) => image.afterParagraph === index + 1);
+              return (
+                <>
+                  <p>{paragraph}</p>
+                  {imagesAfter.length > 0 && (
+                    <div class="deep-media">
+                      {imagesAfter.map((image: any) => (
+                        <figure>
+                          <img
+                            src={resolveImage(image.src)}
+                            alt={image.alt || image.caption || `${item.title} 補足画像`}
+                            loading="lazy"
+                            decoding="async"
+                          />
+                          {image.caption && <figcaption>{image.caption}</figcaption>}
+                        </figure>
+                      ))}
+                    </div>
+                  )}
+                </>
+              );
+            })}
+            {trailingImages.length > 0 && (
+              <div class="deep-media">
+                {trailingImages.map((image: any) => (
+                  <figure>
+                    <img
+                      src={resolveImage(image.src)}
+                      alt={image.alt || image.caption || `${item.title} 補足画像`}
+                      loading="lazy"
+                      decoding="async"
+                    />
+                    {image.caption && <figcaption>{image.caption}</figcaption>}
+                  </figure>
+                ))}
+              </div>
+            )}
+          </div>
+        </details>
+      );
+    })}
   </div>
 </section>
 
 <style>
-  .deep-media{display:grid;gap:18px;margin-top:24px}
+  .deep-media{display:grid;grid-template-columns:minmax(0,1fr);gap:18px;margin:22px 0 28px}
   .deep-media figure{margin:0}
-  .deep-media img{display:block;width:100%;height:auto}
+  .deep-media img{display:block;width:100%;height:auto;border:1px solid rgba(31,28,24,.16)}
   .deep-media figcaption{margin-top:8px;font-size:13px;line-height:1.7;opacity:.72}
+  @media(max-width:480px){
+    .deep-media{margin:18px 0 24px;gap:14px}
+    .deep-media figcaption{font-size:12px;line-height:1.65}
+  }
 </style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,7 +9,7 @@ const watches = defineCollection({
     ownerNumber: z.string(),
     brand: z.string(),
     model: z.string(),
-    catch: z.array(z.string()).length(2),
+    catch: z.array(z.string()).min(1).max(2),
     ownersNote: z.object({
       image: z.string(),
       imageParts: z.array(z.string()).optional(),
@@ -43,7 +43,8 @@ const watches = defineCollection({
       images: z.array(z.object({
         src: z.string(),
         caption: z.string().optional(),
-        alt: z.string().optional()
+        alt: z.string().optional(),
+        afterParagraph: z.number().int().min(1).optional()
       })).optional()
     })),
     sources: z.array(z.string())

--- a/src/content/watches/cyma-time-o-vox.md
+++ b/src/content/watches/cyma-time-o-vox.md
@@ -5,7 +5,6 @@ brand: CYMA
 model: TIME-O-VOX
 catch:
   - 鳴る黄金のクロノメーター
-  - そして、アラームにクロノメーター
 ownersNote:
   image: /images/cyma-time-o-vox/Cyma timeovox .png
   lead:
@@ -86,11 +85,13 @@ deepDive:
       - src: /images/cyma-time-o-vox/ムーブメント.jpg
         caption: Cal.R.464のムーブメント全景
         alt: CYMA Time-O-Vox Cal.R.464 ムーブメント全景
+        afterParagraph: 1
       - src: /images/cyma-time-o-vox/wipe.jpg
         caption: |-
           Wippe（揺動切替機構）と上下プッシャーの作用点。
           プッシャー操作に応じてリューズからの接続先を切り替える。
         alt: CYMA Cal.R.464 Wippeと上下プッシャーの作用点
+        afterParagraph: 2
   - number: "03"
     title: Time-O-Voxのケースとラグ
     paragraphs:


### PR DESCRIPTION
- Allow WATCH catch copy to be one or two lines in both Pages CMS and Astro schema.
- Restore CYMA WATCH hero catch to the single existing line “鳴る黄金のクロノメーター” without changing OWNER'S NOTE copy.
- Add optional per-image paragraph placement for DEEP DIVE media.
- Place the Cal.R.464 overview after paragraph 1 and the Wippe image after paragraph 2.
- Preserve the current OWNER'S NOTES directory link/image state from main.