### PR TITLE
Fix Duofon to CYMA OWNER'S NOTE navigation

### DIFF
--- a/src/layouts/WatchPage.astro
+++ b/src/layouts/WatchPage.astro
@@ -24,7 +24,7 @@ const pagePath = `${watch.slug}/`;
 const pageUrl = new URL(pagePath, siteRoot).href;
 const imageUrl = new URL(watch.ownersNote.image.replace(/^\//, ''), siteRoot).href;
 const nextOwnerNote = watch.slug === 'pierce-duofon'
-  ? { href: 'cyma-time-o-vox/owners-note/', name: 'CYMA TIME-O-VOX' }
+  ? { href: 'cyma-time-o-vox/#owners-note', name: 'CYMA TIME-O-VOX' }
   : watch.slug === 'cyma-time-o-vox'
     ? { href: 'pierce-duofon/#owners-note', name: 'PIERCE DUOFON' }
     : null;


### PR DESCRIPTION
Duofonの末尾「次の変な時計」だけがCYMAの拡大専用OWNER'S NOTEページへ飛んでいたため、CYMA WATCHページのOWNER'S NOTEセクションへ統一します。

既にmainで反映済みのOWNER'S NOTES一覧（CYMA新PNG + /cyma-time-o-vox/#owners-note）は変更しません。本文・画像・CMSデータには触れません。